### PR TITLE
Support loading large zip for Potree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*.tmp.las
+*.tmp.txt
 
+point_clouds
 datasets
 # C extensions
 *.so

--- a/docs/libs/potree/potree.css
+++ b/docs/libs/potree/potree.css
@@ -105,7 +105,7 @@
 	left: 50%; 
 	transform: translateX(-50%); 
 	text-align: center;
-	z-index:	1000;
+	z-index:	99;
 }
 
 #potree_sidebar_container{

--- a/docs/shareloc-potree-viewer.html
+++ b/docs/shareloc-potree-viewer.html
@@ -29,6 +29,7 @@
 	<script src="./libs/jstree/jstree.js"></script>
 	<script src="./libs/potree/potree.js"></script>
 	<script src="./libs/plasio/js/laslaz.js"></script>
+	<script src="https://gildas-lormeau.github.io/zip.js/demos/lib/zip.min.js"></script>
 	
 	<div class="potree_container" style="position: absolute; width: 100%; height: 100%; left: 0px; top: 0px; ">
 		<div id="potree_render_area" style="background-image: url('./libs/potree/resources/images/background.jpg');">
@@ -57,7 +58,7 @@
 			$("#menu_filters").next().show();
 			viewer.toggleSidebar();
 		});
-		
+
 		Potree.loadPointCloud(dataUrl, dataName, function(e){
 			let pointcloud = e.pointcloud;
 			let material = pointcloud.material;

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ LONG_DESCRIPTION = README_FILE.read_text(encoding="utf-8")
 VERSION_FILE = ROOT_DIR / "shareloc_utils" / "VERSION"
 VERSION = json.loads(VERSION_FILE.read_text())["version"]
 
-REQUIRES = []
+REQUIRES = ["numpy", "pyyaml", "pillow", "tqdm"]
 
 setup(
     name="shareloc-utils",


### PR DESCRIPTION
This PR allows loading large zipped potree files.

For example: https://imodpasteur.github.io/shareloc-utils/shareloc-potree-viewer.html?load=https://imjoy-s3.pasteur.fr/public/pointclouds/7312e0.zip


It should work with Zenodo too, however, it's problematic because Zenodo's rate limit: https://imodpasteur.github.io/shareloc-utils/shareloc-potree-viewer.html?load=https://sandbox.zenodo.org/api/files/46c189b4-02a7-4eb6-b677-62750daeb971/7312e0.zip

Here is the error for zenodo:
```
GET https://sandbox.zenodo.org/api/files/46c189b4-02a7-4eb6-b677-62750daeb971/7312e0.zip 429 (TOO MANY REQUESTS)
```

Therefore we should either find another file server or use our own.